### PR TITLE
Store UTC_DATE_SECS as signed INT, to support times before Epoch

### DIFF
--- a/src/main/java/com/g414/st9/proto/service/helper/MySQLTypeHelper.java
+++ b/src/main/java/com/g414/st9/proto/service/helper/MySQLTypeHelper.java
@@ -28,7 +28,7 @@ public class MySQLTypeHelper implements SqlTypeHelper {
         case U64:
             return "BIGINT UNSIGNED";
         case UTC_DATE_SECS:
-            return "INT UNSIGNED";
+            return "INT";
         case REFERENCE:
         case UTF8_SMALLSTRING:
             return "VARCHAR(255)";


### PR DESCRIPTION
Since negative integer times seem to be valid.

Sound reasonable?
